### PR TITLE
feat!: rename project and change sub to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # Changelog
 
-## [0.2.0](https://github.com/dimensionalpocket/dps-auth-session-rs/compare/0.1.0...0.2.0) (2025-11-14)
+## [0.2.0](https://github.com/dimensionalpocket/dps-auth-session/compare/0.1.0...0.2.0) (2025-11-14)
 
 
 ### Features
 
-* project rename ([#8](https://github.com/dimensionalpocket/dps-auth-session-rs/issues/8)) ([698eaad](https://github.com/dimensionalpocket/dps-auth-session-rs/commit/698eaadc92493cff399d457e26a05e5cb28208ac))
+* project rename ([#8](https://github.com/dimensionalpocket/dps-auth-session/issues/8)) ([698eaad](https://github.com/dimensionalpocket/dps-auth-session/commit/698eaadc92493cff399d457e26a05e5cb28208ac))
 
 ## 0.1.0 (2025-07-14)
 
 
 ### Features
 
-* Initial commit ([51c235f](https://github.com/dimensionalpocket/dps-auth-session-rs/commit/51c235f1a46467f6425f60414232aba284a8be09))
+* Initial commit ([51c235f](https://github.com/dimensionalpocket/dps-auth-session/commit/51c235f1a46467f6425f60414232aba284a8be09))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 edition = "2021"
 description = "Secure session token management utilities"
 license = "MIT"
-repository = "https://github.com/dimensionalpocket/dps-auth-session-rs"
+repository = "https://github.com/dimensionalpocket/dps-auth-session"
 authors = ["Dimensional Pocket <dimensionalpocket.com>"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # @dimensionalpocket/dps-auth-session
 
-[![Rust Tests](https://github.com/dimensionalpocket/dps-auth-session-rs/actions/workflows/test.yml/badge.svg)](https://github.com/dimensionalpocket/dps-auth-session-rs/actions/workflows/test.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Rust Tests](https://github.com/dimensionalpocket/dps-auth-session/actions/workflows/test.yml/badge.svg)](https://github.com/dimensionalpocket/dps-auth-session/actions/workflows/test.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 A standalone Rust crate for secure session token management using AES-256-GCM encryption.
 
 ## Features
 
 - **Secure Token Encoding/Decoding**: Uses AES-256-GCM encryption with random nonces
-- **Session Payload Management**: Handles user ID and timestamp information
+- **Session Payload Management**: Handles session ID and timestamp information
 - **Expiration Validation**: Automatically validates token expiration
 - **Comprehensive Error Handling**: Detailed error types for different failure scenarios
 - **Zero External Dependencies**: No database or user management dependencies
@@ -19,7 +19,7 @@ Add this to your `Cargo.toml`:
 <!-- x-release-please-start-version -->
 ```toml
 [dependencies]
-dps-auth-session = { git = "https://github.com/dimensionalpocket/dps-auth-session-rs", tag = "0.2.0" }
+dps-auth-session = { git = "https://github.com/dimensionalpocket/dps-auth-session", tag = "0.2.0" }
 ```
 <!-- x-release-please-end -->
 
@@ -32,8 +32,8 @@ fn main() -> Result<(), DpsAuthSessionError> {
     // Use a proper 32-byte secret key in production
     let secret = &[0u8; 32];
     
-    // Create a session payload for user ID 123
-    let payload = DpsAuthSession::create_payload(123, None);
+    // Create a session payload for session ID "user123"
+    let payload = DpsAuthSession::create_payload("user123".to_string(), None);
     println!("Created session for user: {}", payload.sub);
     
     // Encode the payload into a secure token
@@ -42,7 +42,7 @@ fn main() -> Result<(), DpsAuthSessionError> {
     
     // Decode the token back to payload
     let decoded_payload = DpsAuthSession::decode_token(&token, secret)?;
-    println!("Decoded user ID: {}", decoded_payload.sub);
+    println!("Decoded session ID: {}", decoded_payload.sub);
     
     assert_eq!(payload.sub, decoded_payload.sub);
     Ok(())
@@ -58,7 +58,7 @@ let secret = &[0u8; 32];
 let invalid_token = "invalid-token";
 
 match DpsAuthSession::decode_token(invalid_token, secret) {
-    Ok(payload) => println!("Valid token for user: {}", payload.sub),
+    Ok(payload) => println!("Valid token for session: {}", payload.sub),
     Err(DpsAuthSessionError::TokenExpired) => println!("Token has expired"),
     Err(DpsAuthSessionError::InvalidToken(msg)) => println!("Invalid token: {}", msg),
     Err(DpsAuthSessionError::DecodingError(msg)) => println!("Decoding failed: {}", msg),
@@ -74,7 +74,7 @@ The main struct providing static methods for token operations.
 
 #### Methods
 
-- `create_payload(user_id: i64, expiration_seconds: Option<i64>) -> DpsAuthSessionPayload`
+- `create_payload(sub: String, expiration_seconds: Option<i64>) -> DpsAuthSessionPayload`
   - Creates a new session payload with current timestamp. If `expiration_seconds` is `None`, the default of 3 days is used. If `Some(n)` and `n > 0`, the token expires `n` seconds after issuance.
   
 - `encode_token(payload: &DpsAuthSessionPayload, secret: &[u8]) -> Result<String, DpsAuthSessionError>`
@@ -91,7 +91,7 @@ Session information structure.
 
 #### Fields
 
-- `sub: i64` - Subject (user ID)
+- `sub: String` - Subject (session_id)
 - `iat: i64` - Issued at timestamp (seconds since Unix epoch)
 - `exp: i64` - Expiration timestamp (seconds since Unix epoch)
 
@@ -126,7 +126,7 @@ The crate includes comprehensive unit and integration tests covering:
 - Token encoding/decoding roundtrips
 - Expiration validation
 - Error conditions
-- Edge cases (large user IDs, invalid tokens, etc.)
+- Edge cases (long session IDs, invalid tokens, etc.)
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! use dps_auth_session::{DpsAuthSession, DpsAuthSessionPayload};
 //!
 //! // Create a session payload
-//! let payload = DpsAuthSession::create_payload(123, None);
+//! let payload = DpsAuthSession::create_payload("user123".to_string(), None);
 //!
 //! // Encode to token
 //! let secret = &[0u8; 32]; // Use a proper 32-byte secret in production

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -3,8 +3,8 @@ use serde::{Deserialize, Serialize};
 /// Session payload structure containing user session information
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct DpsAuthSessionPayload {
-  /// Subject - user ID
-  pub sub: i64,
+  /// Subject - session_id
+  pub sub: String,
   /// Issued at timestamp (seconds since epoch)
   pub iat: i64,
   /// Expiration timestamp (seconds since epoch)


### PR DESCRIPTION
This PR renames the project by removing the '-rs' suffix from GitHub URLs and changes the session payload's 'sub' field from an i64 to a String. This is a breaking change.

Key changes:
- URL updates in Cargo.toml, README.md, and CHANGELOG.md.
- DpsAuthSessionPayload::sub type change to String.
- DpsAuthSession::create_payload argument change to sub: String.
- Comprehensive updates to documentation and tests.

---
*PR created automatically by Jules for task [5781877886951121965](https://jules.google.com/task/5781877886951121965) started by @pauldps*